### PR TITLE
Update gemspec to remove pry as a development dependency

### DIFF
--- a/watir-scroll.gemspec
+++ b/watir-scroll.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "watir-scroll"
-  spec.version       = "0.3.0"
+  spec.version       = "0.3.1"
   spec.authors       = "Alex Rodionov"
   spec.email         = "p0deje@gmail.com"
   spec.description   = "Scrolling API for Watir"
@@ -22,5 +22,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "pry"
 end


### PR DESCRIPTION

This looks like a helpful little gem, but I don't want to be forced to install pry just to do a normal gem install.