### PR TITLE
Add offsets and Fix scroll to from anywhere

### DIFF
--- a/lib/watir-scroll/element/scroll.rb
+++ b/lib/watir-scroll/element/scroll.rb
@@ -1,36 +1,45 @@
 module Watir
   class Element
     class Scroll
-
       def initialize(element)
         @element = element
       end
 
       #
       # Scrolls to element.
-      # @param [Symbol] param
+      # @param [Symbol] param Position to which you want to scroll.
+      #   Possibilities are :top, :start, :center, :bottom, :end
+      # @param [Integer] offset_top Vertical offset
+      # @param [Integer] offset_left Horizontal offset
       #
-      def to(param = :top)
+      def to(param = :top, offset_top = 0, offset_left = 0)
         args = case param
                when :top, :start
-                 ['arguments[0].scrollIntoView();', @element]
+                 [
+                   'arguments[0].scrollIntoView();'\
+               "window.scrollBy(#{offset_left},#{offset_top});",
+                   @element
+                 ]
                when :center
-                 script = <<-JS
-                   var elementRect = arguments[0].getBoundingClientRect();
-                   var top = elementRect.top - (window.innerHeight / 2);
-                   var left = elementRect.left - (window.innerWidth / 2);
-                   window.scrollTo(left, top);
-                 JS
-                 [script, @element]
+                 [
+                   'var elementRect = arguments[0].getBoundingClientRect();'\
+               'var top = elementRect.top - (window.innerHeight / 2);' \
+               'var left = elementRect.left - (window.innerWidth / 2);' \
+               "window.scrollTo(left + #{offset_left}, top + #{offset_top});",
+                   @element
+                 ]
                when :bottom, :end
-                 ['arguments[0].scrollIntoView(false);', @element]
+                 [
+                   'arguments[0].scrollIntoView(false);'\
+               "window.scrollBy(#{offset_left},#{offset_top});",
+                   @element
+                 ]
                else
                  raise ArgumentError, "Don't know how to scroll element to: #{param}!"
                end
-
+        @element.browser.execute_script('window.scrollTo(0,0);')
         @element.browser.execute_script(*args)
       end
-
     end # Scroll
   end # Element
 end # Watir


### PR DESCRIPTION
   - Added offsets allow user to move a bit from the position he
        specified. This is good when you have a locked header
        and watir doesnt respect that. You scroll up some px
        and can take full screenshot of the element you scrolled
        to

    - Fix scrolling to was not usable when you already passed the
        element you wanted to scroll to. Now even when you passed
        it you can use scroll_to center again and it will move you
        to the correct element. Previously it would go to 0,0